### PR TITLE
Added a no_collision_mask for BounceBackBoundary

### DIFF
--- a/lettuce/flows/couette.py
+++ b/lettuce/flows/couette.py
@@ -38,7 +38,7 @@ class CouetteFlow2D(object):
     @property
     def boundaries(self):
         x, y = self.grid
-        return [EquilibriumBoundaryPU(np.abs(y-1) < 1e-6, self.units.lattice, np.array([1.0, 0.0])),
+        return [EquilibriumBoundaryPU(np.abs(y-1) < 1e-6, self.units.lattice, self.units, np.array([1.0, 0.0])),
                 BounceBackBoundary(np.abs(y) < 1e-6, self.units.lattice)]
 
 

--- a/lettuce/simulation.py
+++ b/lettuce/simulation.py
@@ -48,6 +48,7 @@ class Simulation:
         for _ in range(num_steps):
             self.i += 1
             self.f = self.streaming(self.f)
+            #Perform the collision routine everywhere, expect where the no_collision_mask is true
             self.f = torch.where(self.no_collision_mask, self.f, self.collision(self.f))
             for boundary in self.flow.boundaries:
                 self.f = boundary(self.f)

--- a/lettuce/simulation.py
+++ b/lettuce/simulation.py
@@ -6,6 +6,7 @@ import pickle
 from copy import deepcopy
 import warnings
 import torch
+import numpy as np
 
 
 class Simulation:
@@ -34,8 +35,8 @@ class Simulation:
         self.reporters = []
 
         # Define a mask, where the collision shall not be applied
-        x, y = flow.grid
-        self.no_collision_mask = x != x
+        x = flow.grid
+        self.no_collision_mask = np.zeros_like(x[0],dtype=bool)
         self.no_collision_mask = lattice.convert_to_tensor(self.no_collision_mask)
         for boundary in self.flow.boundaries:
             if boundary.__class__.__name__ == "BounceBackBoundary":

--- a/lettuce/simulation.py
+++ b/lettuce/simulation.py
@@ -33,13 +33,23 @@ class Simulation:
 
         self.reporters = []
 
+        # Define a mask, where the collision shall not be applied
+        x, y = flow.grid
+        self.no_collision_mask = x != x
+        self.no_collision_mask = lattice.convert_to_tensor(self.no_collision_mask)
+        for boundary in self.flow.boundaries:
+            if boundary.__class__.__name__ == "BounceBackBoundary":
+                self.no_collision_mask = boundary.mask | self.no_collision_mask
+
     def step(self, num_steps):
         """Take num_steps stream-and-collision steps and return performance in MLUPS."""
         start = timer()
         for _ in range(num_steps):
             self.i += 1
             self.f = self.streaming(self.f)
-            self.f = self.collision(self.f)
+            self.f = torch.where(self.no_collision_mask, self.f, self.collision(self.f))
+            for boundary in self.flow.boundaries:
+                self.f = boundary(self.f)
             for reporter in self.reporters:
                 reporter(self.i, self.i, self.f)
         end = timer()


### PR DESCRIPTION
We recognized a bug in the bounce back scheme. If the collision is applied to the boundary nodes, then garbage values stream into the fluid. To apply a full way bounce back, the collision has to be switched off on the boundary nodes.

I am still unsure, whether this is the best way to implement such a no_collision scheme, so perhaps we discuss it first.