### PR TITLE
TGV3D Bugfix

### DIFF
--- a/lettuce/flows/taylorgreen.py
+++ b/lettuce/flows/taylorgreen.py
@@ -44,7 +44,7 @@ class TaylorGreenVortex3D:
         self.units = UnitConversion(
             lattice,
             reynolds_number=reynolds_number, mach_number=mach_number,
-            characteristic_length_lu=resolution, characteristic_length_pu=2*np.pi,
+            characteristic_length_lu=resolution/(2*np.pi), characteristic_length_pu=1,
             characteristic_velocity_pu=1
         )
 


### PR DESCRIPTION
TGV3D is defined with Re=1/nu    ---- unlike the TGV2D

So the characteristic_length_pu is 1 and the corresponding characteristic_length_lu is resolution/(2*pi).