### PR TITLE
vtk reporter now outputs collision mask

### DIFF
--- a/lettuce/reporters.py
+++ b/lettuce/reporters.py
@@ -43,6 +43,18 @@ class VTKReporter:
         if not os.path.isdir(directory):
             os.mkdir(directory)
         self.point_dict = dict()
+        if hasattr(self.flow, "mask"):
+            if self.flow.mask is not None:
+                if self.lattice.D == 2:
+                    self.point_dict["mask"] = self.lattice.convert_to_numpy(flow.mask[..., None])
+                else:
+                    self.point_dict["mask"] = self.lattice.convert_to_numpy(flow.mask)
+            vtk.gridToVTK(self.filename_base + "mask",
+                          np.arange(0, self.point_dict["mask"].shape[0]),
+                          np.arange(0, self.point_dict["mask"].shape[1]),
+                          np.arange(0, self.point_dict["mask"].shape[2]),
+                          pointData=self.point_dict)
+            self.point_dict = dict()
 
     def __call__(self, i, t, f):
         if t % self.interval == 0:


### PR DESCRIPTION
I wanted to be able to include my bounce back mask in ParaView, so I made the vtk reporter output it as vtk file at the start of the simulation. Tested it for 2D and 3D mask output.