### PR TITLE
Updated the error reporter to now (hopefully) work in 1D and 3D as well

### DIFF
--- a/lettuce/reporters.py
+++ b/lettuce/reporters.py
@@ -82,8 +82,8 @@ class ErrorReporter:
 
             resolution = torch.pow(torch.prod(self.lattice.convert_to_tensor(p.size())),1/self.lattice.D)
 
-            err_u = torch.norm(u-uref)/resolution
-            err_p = torch.norm(p-pref)/resolution
+            err_u = torch.norm(u-uref)/resolution**(self.lattice.D/2)
+            err_p = torch.norm(p-pref)/resolution**(self.lattice.D/2)
 
             if isinstance(self.out, list):
                 self.out.append([err_u.item(), err_p.item()])


### PR DESCRIPTION

(Here example for deduction: all errors are 0.5, then in 1D the norm is: sqrt(0.5² * res) = 0.5 * sqrt(res), in 2D it is: sqrt(0.5² * res * res) = 0.5 * res = 0.5 * sqrt(res)² and in 3D it is sqrt(0.5² * res * res * res) = 0.5 * res * sqrt(res) = 0.5 * sqrt(res)³)

(i wrote it as res^(D/2) thinking it migth be faster than sqrt(res)^D)