### PR TITLE
Report zeroth step

### DIFF
--- a/lettuce/reporters.py
+++ b/lettuce/reporters.py
@@ -104,12 +104,11 @@ class GenericStepReporter:
 
     def __call__(self, i, t, f):
         if t % self.interval == 0:
-            if t > self.starting_iteration:
-                entry = [t, self.parameter_function(i,t,f)]
-                if isinstance(self.out, list):
-                    self.out.append(entry)
-                else:
-                    print(*entry, file=self.out)
+            entry = [t, self.parameter_function(i,t,f)]
+            if isinstance(self.out, list):
+                self.out.append(entry)
+            else:
+                print(*entry, file=self.out)
 
     def parameter_function(self,i,t,f):
         return NotImplemented

--- a/lettuce/simulation.py
+++ b/lettuce/simulation.py
@@ -18,7 +18,7 @@ class Simulation:
     Attributes
     ----------
     reporters : list
-        A list of reporters. Their call functions are invoked before every simulation step.
+        A list of reporters. Their call functions are invoked after every simulation step (and before the first one).
 
     """
     def __init__(self, flow, lattice, collision, streaming):
@@ -55,20 +55,25 @@ class Simulation:
     def step(self, num_steps):
         """Take num_steps stream-and-collision steps and return performance in MLUPS."""
         start = timer()
+        if self.i == 0:
+            self._report()
         for _ in range(num_steps):
-            for reporter in self.reporters:
-                reporter(self.i, self.i, self.f)
             self.i += 1
             self.f = self.streaming(self.f)
             #Perform the collision routine everywhere, expect where the no_collision_mask is true
             self.f = torch.where(self.no_collision_mask, self.f, self.collision(self.f))
             for boundary in self.flow.boundaries:
                 self.f = boundary(self.f)
+            self._report()
         end = timer()
         seconds = end-start
         num_grid_points = self.lattice.rho(self.f).numel()
         mlups = num_steps * num_grid_points / 1e6 / seconds
         return mlups
+
+    def _report(self):
+        for reporter in self.reporters:
+            reporter(self.i, self.i, self.f)
 
     def initialize(self, max_num_steps=500, tol_pressure=0.001):
         """Iterative initialization to get moments consistent with the initial velocity.

--- a/lettuce/simulation.py
+++ b/lettuce/simulation.py
@@ -18,7 +18,7 @@ class Simulation:
     Attributes
     ----------
     reporters : list
-        A list of reporters. Their call functions are invoked after every simulation step.
+        A list of reporters. Their call functions are invoked before every simulation step.
 
     """
     def __init__(self, flow, lattice, collision, streaming):
@@ -56,14 +56,14 @@ class Simulation:
         """Take num_steps stream-and-collision steps and return performance in MLUPS."""
         start = timer()
         for _ in range(num_steps):
+            for reporter in self.reporters:
+                reporter(self.i, self.i, self.f)
             self.i += 1
             self.f = self.streaming(self.f)
             #Perform the collision routine everywhere, expect where the no_collision_mask is true
             self.f = torch.where(self.no_collision_mask, self.f, self.collision(self.f))
             for boundary in self.flow.boundaries:
                 self.f = boundary(self.f)
-            for reporter in self.reporters:
-                reporter(self.i, self.i, self.f)
         end = timer()
         seconds = end-start
         num_grid_points = self.lattice.rho(self.f).numel()

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -21,16 +21,17 @@ def test_write_image(tmpdir):
 def test_generic_reporters(Reporter, Case, dtype_device):
     dtype, device = dtype_device
     lattice = Lattice(D2Q9, dtype=dtype, device=device)
-    flow = Case(64, 10000, 0.05, lattice=lattice)
+    flow = Case(32, 10000, 0.05, lattice=lattice)
     if Case == TaylorGreenVortex3D:
         lattice = Lattice(D3Q27, dtype=dtype, device=device)
     collision = BGKCollision(lattice, tau=flow.units.relaxation_parameter_lu)
     streaming = StandardStreaming(lattice)
     simulation = Simulation(flow=flow, lattice=lattice, collision=collision, streaming=streaming)
-    kinE_reporter = Reporter(lattice, flow, interval=1, out=None)
-    simulation.reporters.append(kinE_reporter)
+    reporter = Reporter(lattice, flow, interval=1, out=None)
+    simulation.reporters.append(reporter)
     simulation.step(2)
-    assert(np.asarray(kinE_reporter.out)[1,1] == pytest.approx(np.asarray(kinE_reporter.out)[0,1], rel=0.05))
+    values = np.asarray(reporter.out)
+    assert(values[1,1] == pytest.approx(values[0,1], rel=0.05))
 
 
 def test_write_vtk(tmpdir):
@@ -52,5 +53,5 @@ def test_vtk_reporter(tmpdir):
     vtk_reporter = VTKReporter(lattice, flow, interval=1, filename_base=tmpdir/"output")
     simulation.reporters.append(vtk_reporter)
     simulation.step(2)
+    assert os.path.isfile(tmpdir/"output_00000000.vtr")
     assert os.path.isfile(tmpdir/"output_00000001.vtr")
-    assert os.path.isfile(tmpdir/"output_00000002.vtr")


### PR DESCRIPTION
In many cases we want to actually have access to the output at t=0.
Therefore, I moved the reporting to the beginning of the simulation step.

@dominikwilde @McBs @MartinKliemank 
Please tell me, if you don't agree with this.