### PR TITLE
Observable module

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -47,6 +47,15 @@ Collision
     :show-inheritance:
 
 
+Observables
+-----------
+.. automodule:: lettuce.observables
+    :noindex:
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Reporters
 ---------
 .. automodule:: lettuce.reporters

--- a/lettuce/__init__.py
+++ b/lettuce/__init__.py
@@ -23,6 +23,7 @@ from lettuce.boundary import *
 from lettuce.reporters import *
 from lettuce.simulation import *
 from lettuce.force import *
+from lettuce.observables import *
 
 from lettuce.flows import *
 

--- a/lettuce/observables.py
+++ b/lettuce/observables.py
@@ -1,0 +1,93 @@
+"""
+Observables.
+Each observable is defined as a callable class.
+The `__call__` function takes f as an argument and returns a torch tensor.
+"""
+
+
+import torch
+import numpy as np
+from lettuce.util import torch_gradient
+
+
+class MaximumVelocity:
+    """Maximum velocitiy"""
+    def __init__(self, lattice, flow):
+        self.lattice = lattice
+        self.flow = flow
+
+    def __call__(self, f):
+        u = self.lattice.u(f)
+        return self.flow.units.convert_velocity_to_pu(torch.norm(u, dim=0).max())
+
+
+class IncompressibleKineticEnergy:
+    """Total kinetic energy of an incompressible flow."""
+    def __init__(self, lattice, flow):
+        self.lattice = lattice
+        self.flow = flow
+
+    def __call__(self, f):
+        dx = self.flow.units.convert_length_to_pu(1.0)
+        kinE = self.flow.units.convert_incompressible_energy_to_pu(torch.sum(self.lattice.incompressible_energy(f)))
+        kinE *= dx ** self.lattice.D
+        return kinE
+
+
+class Enstrophy:
+    """The integral of the vorticity
+
+    Notes
+    -----
+    The function only works for periodic domains
+    """
+    def __init__(self, lattice, flow):
+        self.lattice = lattice
+        self.flow = flow
+
+    def __call__(self, f):
+        u0 = self.flow.units.convert_velocity_to_pu(self.lattice.u(f)[0])
+        u1 = self.flow.units.convert_velocity_to_pu(self.lattice.u(f)[1])
+        dx = self.flow.units.convert_length_to_pu(1.0)
+        grad_u0 = torch_gradient(u0, dx=dx, order=6)
+        grad_u1 = torch_gradient(u1, dx=dx, order=6)
+        vorticity = torch.sum((grad_u0[1] - grad_u1[0]) * (grad_u0[1] - grad_u1[0]))
+        if self.lattice.D == 3:
+            u2 = self.flow.units.convert_velocity_to_pu(self.lattice.u(f)[2])
+            grad_u2 = torch_gradient(u2, dx=dx, order=6)
+            vorticity += torch.sum(
+                (grad_u2[1] - grad_u1[2]) * (grad_u2[1] - grad_u1[2])
+                + ((grad_u0[2] - grad_u2[0]) * (grad_u0[2] - grad_u2[0]))
+            )
+        return vorticity * dx**self.lattice.D
+
+
+class EnergySpectrum:
+    """The kinetic energy spectrum"""
+    def __init__(self, lattice, flow):
+        self.lattice =lattice
+        self.flow = flow
+        self.dx = self.flow.units.convert_length_to_pu(1.0)
+        self.dimensions = self.flow.grid[0].shape
+        frequencies = [self.lattice.convert_to_tensor(np.fft.fftfreq(dim, d=1 / dim)) for dim in self.dimensions]
+        wavenumbers = torch.stack(torch.meshgrid(*frequencies))
+        wavenorms = torch.norm(wavenumbers, dim=0)
+        self.norm = self.dimensions[0] * np.sqrt(2 * np.pi) / self.dx ** 2 if self.lattice.D == 3 else self.dimensions[0] / self.dx
+        self.wavenumbers = torch.arange(int(torch.max(wavenorms)))
+        self.wavemask = (
+            (wavenorms[..., None] > self.wavenumbers.to(dtype=lattice.dtype) - 0.5) &
+            (wavenorms[..., None] <= self.wavenumbers.to(dtype=lattice.dtype) + 0.5)
+        )
+
+    def __call__(self, f):
+        u = self.flow.units.convert_velocity_to_pu(self.lattice.u(f))
+        zeros = torch.zeros(self.dimensions, dtype=self.lattice.dtype, device=self.lattice.device)[..., None]
+        uh = (torch.stack([
+            torch.fft(torch.cat((u[i][..., None], zeros), self.lattice.D),
+                      signal_ndim=self.lattice.D) for i in range(self.lattice.D)]) / self.norm)
+        ekin = torch.sum(0.5 * (uh[...,0]**2 + uh[...,1]**2), dim=0)
+        ek = ekin[..., None] * self.wavemask.to(dtype=self.lattice.dtype)
+        ek = ek.sum(torch.arange(self.lattice.D).tolist())
+        return ek
+
+

--- a/lettuce/observables.py
+++ b/lettuce/observables.py
@@ -10,6 +10,9 @@ import numpy as np
 from lettuce.util import torch_gradient
 
 
+__all__ = ["MaximumVelocity", "IncompressibleKineticEnergy", "Enstrophy", "EnergySpectrum"]
+
+
 class MaximumVelocity:
     """Maximum velocitiy"""
     def __init__(self, lattice, flow):

--- a/lettuce/reporters.py
+++ b/lettuce/reporters.py
@@ -4,11 +4,11 @@ TODO: Logging
 """
 
 import sys
+import warnings
+import os
 import numpy as np
 import torch
-import os
 import pyevtk.hl as vtk
-from lettuce.util import torch_gradient
 
 
 def write_image(filename, array2d):
@@ -126,24 +126,36 @@ class ObservableReporter:
                 print(*entry, file=self.out)
 
 
+# ----------------------------------------
 # Deprecated classes
+# ----------------------------------------
+# These remainder of this file is only for backwards compatibility. It will eventually be deleted.
+
 
 class GenericStepReporter:
     def __init__(self, *args, **kwargs):
         raise NotImplementedError(f"{self.__class__.__name__} is deprecated. Use ObservableReporter instead.")
 
 
-class MaxUReporter(GenericStepReporter):
-    pass
+def MaxUReporter(lattice, flow, interval=1, starting_iteration=0, out=sys.stdout):
+    warnings.warn("MaxUReporter is deprecated. Use ObservableReporter(MaximumVelocity, ...) instead.")
+    from lettuce.observables import MaximumVelocity
+    return ObservableReporter(MaximumVelocity(lattice, flow), interval=interval, out=out)
 
 
-class EnergyReporter(GenericStepReporter):
-    pass
+def EnergyReporter(lattice, flow, interval=1, starting_iteration=0, out=sys.stdout):
+    warnings.warn("EnergyReporter is deprecated. Use ObservableReporter(IncompressibleKineticEnergy, ...) instead.")
+    from lettuce.observables import IncompressibleKineticEnergy
+    return ObservableReporter(IncompressibleKineticEnergy(lattice, flow), interval=interval, out=out)
 
 
-class EnstrophyReporter(GenericStepReporter):
-    pass
+def EnstrophyReporter(lattice, flow, interval=1, starting_iteration=0, out=sys.stdout):
+    warnings.warn("EnstrophyReporter is deprecated. Use ObservableReporter(Enstrophy, ...) instead.")
+    from lettuce.observables import Enstrophy
+    return ObservableReporter(Enstrophy(lattice, flow), interval=interval, out=out)
 
 
-class SpectrumReporter(GenericStepReporter):
-    pass
+def SpectrumReporter(lattice, flow, interval=1, starting_iteration=0, out=sys.stdout):
+    warnings.warn("SpectrumReporter is deprecated. Use ObservableReporter(EnergySpectrum, ...) instead.")
+    from lettuce.observables import EnergySpectrum
+    return ObservableReporter(EnergySpectrum(lattice, flow), interval=interval, out=out)

--- a/lettuce/reporters.py
+++ b/lettuce/reporters.py
@@ -72,7 +72,6 @@ class ErrorReporter:
 
     def __call__(self, i, t, f):
         if i % self.interval == 0:
-            t = self.flow.units.convert_time_to_pu(t)
             pref, uref = self.flow.analytic_solution(self.flow.grid, t=t)
             pref = self.lattice.convert_to_tensor(pref)
             uref = self.lattice.convert_to_tensor(uref)

--- a/lettuce/reporters.py
+++ b/lettuce/reporters.py
@@ -91,7 +91,20 @@ class ErrorReporter:
 
 
 class ObservableReporter:
-    """A reporter that prints an observable every few iterations."""
+    """A reporter that prints an observable every few iterations.
+
+    Examples
+    --------
+    Create an Enstrophy reporter.
+
+    >>> from lettuce import TaylorGreenVortex3D, Enstrophy, D3Q27, Lattice
+    >>> lattice = Lattice(D3Q27, device="cpu")
+    >>> flow = TaylorGreenVortex(50, 300, 0.1, lattice)
+    >>> enstrophy = Enstrophy(lattice, flow)
+    >>> reporter = ObservableReporter(enstrophy, interval=10)
+    >>> # simulation = ...
+    >>> # simulation.reporters.append(reporter)
+    """
     def __init__(self, observable, interval=1, out=sys.stdout):
         self.observable = observable
         self.interval = interval
@@ -112,3 +125,26 @@ class ObservableReporter:
                 self.out.append(entry)
             else:
                 print(*entry, file=self.out)
+
+
+# Deprecated classes
+
+class GenericStepReporter:
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError(f"{self.__class__.__name__} is deprecated. Use ObservableReporter instead.")
+
+
+class MaxUReporter(GenericStepReporter):
+    pass
+
+
+class EnergyReporter(GenericStepReporter):
+    pass
+
+
+class EnstrophyReporter(GenericStepReporter):
+    pass
+
+
+class SpectrumReporter(GenericStepReporter):
+    pass

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -1,0 +1,35 @@
+
+import pytest
+
+import numpy as np
+from lettuce import Lattice, D2Q9, D3Q27, BGKCollision, DecayingTurbulence, StandardStreaming, Simulation
+from lettuce.flows.taylorgreen import TaylorGreenVortex3D, TaylorGreenVortex2D
+from lettuce.observables import EnergySpectrum, IncompressibleKineticEnergy
+
+
+@pytest.mark.parametrize("Flow", [TaylorGreenVortex2D, TaylorGreenVortex3D, 'DecayingTurbulence2D', 'DecayingTurbulence3D'])
+def test_energy_spectrum_reporter(tmpdir, Flow):
+    lattice = Lattice(D2Q9, device='cpu')
+    if Flow == TaylorGreenVortex3D or Flow == 'DecayingTurbulence3D':
+        lattice = Lattice(D3Q27, device='cpu')
+    if Flow == 'DecayingTurbulence2D' or Flow == 'DecayingTurbulence3D':
+        Flow = DecayingTurbulence
+    flow = Flow(resolution=20, reynolds_number=1600, mach_number=0.01, lattice=lattice)
+    collision = BGKCollision(lattice, tau=flow.units.relaxation_parameter_lu)
+    streaming = StandardStreaming(lattice)
+    simulation = Simulation(flow=flow, lattice=lattice, collision=collision, streaming=streaming)
+    spectrum = lattice.convert_to_numpy(EnergySpectrum(lattice, flow)(simulation.f))
+    energy = IncompressibleKineticEnergy(lattice, flow)(simulation.f).item()
+
+    if Flow == DecayingTurbulence:
+        # check that the reported spectrum agrees with the spectrum used for initialization
+        ek_ref, _ = flow.energy_spectrum
+        assert (spectrum == pytest.approx(ek_ref, rel=0.0, abs=0.1))
+    if Flow == TaylorGreenVortex2D or Flow == TaylorGreenVortex3D:
+        # check that flow has only one mode
+        ek_max = sorted(spectrum, reverse=True)
+        assert ek_max[0]*1e-5>ek_max[1]
+    assert (energy == pytest.approx(np.sum(spectrum), rel=0.1, abs=0.0))
+
+
+

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -2,7 +2,8 @@
 import pytest
 import os
 from lettuce import TaylorGreenVortex2D, TaylorGreenVortex3D, Lattice, D3Q27, D2Q9, write_image, BGKCollision, StandardStreaming, Simulation, DecayingTurbulence
-from lettuce.reporters import write_vtk, VTKReporter,EnstrophyReporter,EnergyReporter,MaxUReporter,SpectrumReporter
+from lettuce.reporters import write_vtk, VTKReporter, ObservableReporter #,EnstrophyReporter,EnergyReporter,MaxUReporter,SpectrumReporter
+from lettuce.observables import Enstrophy, EnergySpectrum, MaximumVelocity, IncompressibleKineticEnergy
 import numpy as np
 import torch
 
@@ -17,9 +18,9 @@ def test_write_image(tmpdir):
     assert os.path.isfile(tmpdir/"p.png")
 
 
-@pytest.mark.parametrize("Reporter", [EnstrophyReporter, EnergyReporter, MaxUReporter])
+@pytest.mark.parametrize("Observable", [Enstrophy, EnergySpectrum, MaximumVelocity, IncompressibleKineticEnergy])
 @pytest.mark.parametrize("Case", [TaylorGreenVortex2D,TaylorGreenVortex3D])
-def test_generic_reporters(Reporter, Case, dtype_device):
+def test_generic_reporters(Observable, Case, dtype_device):
     dtype, device = dtype_device
     lattice = Lattice(D2Q9, dtype=dtype, device=device)
     flow = Case(32, 10000, 0.05, lattice=lattice)
@@ -28,11 +29,14 @@ def test_generic_reporters(Reporter, Case, dtype_device):
     collision = BGKCollision(lattice, tau=flow.units.relaxation_parameter_lu)
     streaming = StandardStreaming(lattice)
     simulation = Simulation(flow=flow, lattice=lattice, collision=collision, streaming=streaming)
-    reporter = Reporter(lattice, flow, interval=1, out=None)
+    reporter = ObservableReporter(Observable(lattice, flow), interval=1, out=None)
     simulation.reporters.append(reporter)
     simulation.step(2)
     values = np.asarray(reporter.out)
-    assert(values[1,1] == pytest.approx(values[0,1], rel=0.05))
+    if Observable is EnergySpectrum:
+        assert (values[1, 2:] == pytest.approx(values[0, 2:], rel=0.0, abs=values[0, 2:].sum()/10))
+    else:
+        assert(values[1, 2] == pytest.approx(values[0, 2], rel=0.05))
 
 
 def test_write_vtk(tmpdir):
@@ -56,34 +60,4 @@ def test_vtk_reporter(tmpdir):
     simulation.step(2)
     assert os.path.isfile(tmpdir/"output_00000000.vtr")
     assert os.path.isfile(tmpdir/"output_00000001.vtr")
-
-
-@pytest.mark.parametrize("Flow", [TaylorGreenVortex2D, TaylorGreenVortex3D, 'DecayingTurbulence2D', 'DecayingTurbulence3D'])
-def test_energy_spectrum_reporter(tmpdir, Flow):
-    lattice = Lattice(D2Q9, device='cpu')
-    if Flow == TaylorGreenVortex3D or Flow == 'DecayingTurbulence3D':
-        lattice = Lattice(D3Q27, device='cpu')
-    if Flow == 'DecayingTurbulence2D' or Flow == 'DecayingTurbulence3D':
-        Flow = DecayingTurbulence
-    flow = Flow(resolution=20, reynolds_number=1600, mach_number=0.01, lattice=lattice)
-    collision = BGKCollision(lattice, tau=flow.units.relaxation_parameter_lu)
-    streaming = StandardStreaming(lattice)
-    simulation = Simulation(flow=flow, lattice=lattice, collision=collision, streaming=streaming)
-    simulation.reporters.append(SpectrumReporter(lattice, flow, out=None))
-    simulation.reporters.append(EnergyReporter(lattice, flow, out=None))
-    simulation.step(1)
-    spectrum = simulation.reporters[0].out
-    energy = simulation.reporters[1].out
-
-    if Flow == DecayingTurbulence:
-        # check that the reported spectrum agrees with the spectrum used for initialization
-        ek_ref, _ = flow.energy_spectrum
-        assert (spectrum[0][1] == pytest.approx(ek_ref, rel= 0.0, abs=0.1))
-    if Flow == TaylorGreenVortex2D or Flow == TaylorGreenVortex3D:
-        # check that flow has only one mode
-        ek_max = sorted(spectrum[0][1], reverse=True)
-        assert ek_max[0]*1e-5>ek_max[1]
-    assert (energy[0][1] == pytest.approx(torch.sum(spectrum[0][1]).numpy(), rel= 0.1, abs=0.0))
-
-
 

--- a/tests/test_stencils.py
+++ b/tests/test_stencils.py
@@ -1,15 +1,23 @@
 
 import pytest
+import numpy as np
 
 
 def test_opposite(lattice):
     """Test if the opposite field holds the index of the opposite direction."""
     assert lattice.e[lattice.stencil.opposite].cpu().numpy() == pytest.approx(-lattice.e.cpu().numpy())
 
+
 def test_symmetry(lattice):
     """Test if the stencil is symmetric"""
     assert sum(sum(lattice.e.cpu().numpy())) == pytest.approx(0.0)
 
+
 def test_weights(lattice):
     """Test if the sum of all weights equals one."""
     assert sum(lattice.w.cpu().numpy()) == pytest.approx(1.0)
+
+
+def test_first_zero(lattice):
+    """Test that the zeroth velocity is 0."""
+    assert lattice.stencil.e[0] == pytest.approx(np.zeros_like(lattice.stencil.e[0]))


### PR DESCRIPTION
Separate the computation of observables from reporting.
Breaking change: Deleted `GenericStepReporter` and subclasses in lieu of `ObservableReporter`

New usage example:

```
from lettuce import TaylorGreenVortex3D, Enstrophy, D3Q27, Lattice
lattice = Lattice(D3Q27, device="cpu")
flow = TaylorGreenVortex(50, 300, 0.1, lattice)
enstrophy = Enstrophy(lattice, flow)
reporter = ObservableReporter(enstrophy, interval=10)
```

The advantage is that observables can also be computed outside a reporter. This is important, for example when we want to backpropagate through an observable in a loss function.

@MartinKliemank @McBs @dominikwilde  This will break the old API. Please take note.